### PR TITLE
Adjust to new backend-v2 interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,4 @@ require (
 	gotest.tools v2.2.0+incompatible
 )
 
-replace github.com/emersion/go-imap => github.com/foxcpp/go-imap v1.0.0-beta.1.0.20200802083659-cf943ff91d80
+replace github.com/emersion/go-imap => github.com/foxcpp/go-imap v1.0.0-beta.1.0.20201001193006-5a1d05e53e2c

--- a/mailbox_appendlimit.go
+++ b/mailbox_appendlimit.go
@@ -33,7 +33,7 @@ func Backend_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackF
 		mbox := getMbox(t, u, nil)
 		defer mbox.Close()
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+headerStub+strings.Repeat("A", 300)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+headerStub+strings.Repeat("A", 300)), mbox)
 		assert.NilError(t, err)
 	})
 	t.Run("Under Limit", func(t *testing.T) {
@@ -44,7 +44,7 @@ func Backend_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackF
 		mbox := getMbox(t, u, nil)
 		defer mbox.Close()
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 300)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 300)), mbox)
 		assert.NilError(t, err)
 	})
 	t.Run("Over Limit", func(t *testing.T) {
@@ -55,7 +55,7 @@ func Backend_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackF
 		mbox := getMbox(t, u, nil)
 		defer mbox.Close()
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)), mbox)
 		assert.Error(t, err, appendlimit.ErrTooBig.Error())
 	})
 }
@@ -84,7 +84,7 @@ func User_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackFunc
 		mbox := getMbox(t, u, nil)
 		defer mbox.Close()
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 300)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 300)), mbox)
 		assert.NilError(t, err)
 	})
 	t.Run("Under Limit", func(t *testing.T) {
@@ -95,7 +95,7 @@ func User_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackFunc
 		mbox := getMbox(t, u, nil)
 		defer mbox.Close()
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 300)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 300)), mbox)
 		assert.NilError(t, err)
 	})
 	t.Run("Over Limit", func(t *testing.T) {
@@ -106,7 +106,7 @@ func User_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackFunc
 		mbox := getMbox(t, u, nil)
 		defer mbox.Close()
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)), mbox)
 		assert.Error(t, err, appendlimit.ErrTooBig.Error())
 	})
 	t.Run("Override backend - Under Limit", func(t *testing.T) {
@@ -119,7 +119,7 @@ func User_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackFunc
 		mbox := getMbox(t, u, nil)
 		defer mbox.Close()
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 400)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 400)), mbox)
 		assert.NilError(t, err)
 	})
 	t.Run("Override backend - Over Limit", func(t *testing.T) {
@@ -132,7 +132,7 @@ func User_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackFunc
 		mbox := getMbox(t, u, nil)
 		defer mbox.Close()
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)), mbox)
 		assert.Error(t, err, appendlimit.ErrTooBig.Error())
 	})
 }
@@ -170,7 +170,7 @@ func Mailbox_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackF
 		defer mbox.Close()
 		setMboxLim(t, mbox, 500)
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 300)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 300)), mbox)
 		assert.NilError(t, err)
 	})
 	t.Run("Under Limit", func(t *testing.T) {
@@ -180,7 +180,7 @@ func Mailbox_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackF
 		defer mbox.Close()
 		setMboxLim(t, mbox, 500)
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 300)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 300)), mbox)
 		assert.NilError(t, err)
 	})
 	t.Run("Over Limit", func(t *testing.T) {
@@ -190,7 +190,7 @@ func Mailbox_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackF
 		defer mbox.Close()
 		setMboxLim(t, mbox, 500)
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)), mbox)
 		assert.Error(t, err, appendlimit.ErrTooBig.Error())
 	})
 	t.Run("Override backend - Under Limit", func(t *testing.T) {
@@ -198,11 +198,11 @@ func Mailbox_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackF
 
 		lim := uint32(100)
 		assert.NilError(t, bAL.SetMessageLimit(&lim))
-		mbox := getMbox(t, u,nil)
+		mbox := getMbox(t, u, nil)
 		defer mbox.Close()
 		setMboxLim(t, mbox, 500)
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 400)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 400)), mbox)
 		assert.NilError(t, err)
 	})
 	t.Run("Override backend - Over Limit", func(t *testing.T) {
@@ -215,7 +215,7 @@ func Mailbox_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackF
 		mbox := getMbox(t, u, nil)
 		defer mbox.Close()
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)), mbox)
 		assert.Error(t, err, appendlimit.ErrTooBig.Error())
 	})
 	t.Run("Override user - Under Limit", func(t *testing.T) {
@@ -227,7 +227,7 @@ func Mailbox_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackF
 		defer mbox.Close()
 		setMboxLim(t, mbox, 500)
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 400)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 400)), mbox)
 		assert.NilError(t, err)
 	})
 	t.Run("Override user - Over Limit", func(t *testing.T) {
@@ -240,7 +240,7 @@ func Mailbox_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackF
 		mbox := getMbox(t, u, nil)
 		defer mbox.Close()
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)), mbox)
 		assert.Error(t, err, appendlimit.ErrTooBig.Error())
 	})
 	t.Run("Override backend & user - Under Limit", func(t *testing.T) {
@@ -256,7 +256,7 @@ func Mailbox_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackF
 		defer mbox.Close()
 		setMboxLim(t, mbox, 500)
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 400)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 400)), mbox)
 		assert.NilError(t, err)
 	})
 	t.Run("Override backend & user - Over Limit", func(t *testing.T) {
@@ -270,7 +270,7 @@ func Mailbox_AppendLimit(t *testing.T, newBack NewBackFunc, closeBack CloseBackF
 		defer mbox.Close()
 		setMboxLim(t, mbox, 500)
 
-		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)))
+		err := u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(headerStub+strings.Repeat("A", 700)), mbox)
 		assert.Error(t, err, appendlimit.ErrTooBig.Error())
 	})
 	t.Run("Status - No Limit", func(t *testing.T) {

--- a/mailbox_encoded_headers.go
+++ b/mailbox_encoded_headers.go
@@ -34,7 +34,7 @@ func Mailbox_FetchEncoded(t *testing.T, newBack NewBackFunc, closeBack CloseBack
 	defer u.Logout()
 	mbox := getMbox(t, u, nil)
 	defer mbox.Close()
-	assert.NilError(t, u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(encodedTestMsg)))
+	assert.NilError(t, u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(encodedTestMsg), mbox))
 	assert.NilError(t, mbox.Poll(true))
 	seq, _ := imap.ParseSeqSet("1")
 
@@ -95,7 +95,7 @@ func Mailbox_MatchEncoded(t *testing.T, newBack NewBackFunc, closeBack CloseBack
 	defer u.Logout()
 	mbox := getMbox(t, u, nil)
 	defer mbox.Close()
-	assert.NilError(t, u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(encodedTestMsg)))
+	assert.NilError(t, u.CreateMessage(mbox.Name(), []string{}, time.Now(), strings.NewReader(encodedTestMsg), mbox))
 	assert.NilError(t, mbox.Poll(true))
 
 	t.Run("header", func(t *testing.T) {

--- a/mailbox_fetchitems.go
+++ b/mailbox_fetchitems.go
@@ -142,10 +142,10 @@ func Mailbox_ListMessages_BodyPeek(t *testing.T, newBack NewBackFunc, closeBack 
 		defer mbox.Close()
 
 		date := time.Now()
-		err := u.CreateMessage(mbox.Name(), []string{"$Test1", "$Test2"}, date, strings.NewReader(testMailString))
+		err := u.CreateMessage(mbox.Name(), []string{"$Test1", "$Test2"}, date, strings.NewReader(testMailString), mbox)
 		assert.NilError(t, err)
 		assert.NilError(t, mbox.Poll(true))
-		
+
 		conn.upds = nil
 
 		seq, _ := imap.ParseSeqSet("1")
@@ -175,7 +175,7 @@ func Mailbox_ListMessages_BodyPeek(t *testing.T, newBack NewBackFunc, closeBack 
 		defer mbox.Close()
 
 		date := time.Now()
-		err := u.CreateMessage(mbox.Name(), []string{"$Test1", "$Test2"}, date, strings.NewReader(testMailString))
+		err := u.CreateMessage(mbox.Name(), []string{"$Test1", "$Test2"}, date, strings.NewReader(testMailString), mbox)
 		assert.NilError(t, err)
 		assert.NilError(t, mbox.Poll(true))
 
@@ -199,7 +199,7 @@ func Mailbox_ListMessages_BodyPeek(t *testing.T, newBack NewBackFunc, closeBack 
 		defer mbox.Close()
 
 		date := time.Now()
-		err := u.CreateMessage(mbox.Name(), []string{"$Test1", "$Test2"}, date, strings.NewReader(testMailString))
+		err := u.CreateMessage(mbox.Name(), []string{"$Test1", "$Test2"}, date, strings.NewReader(testMailString), mbox)
 		assert.NilError(t, err)
 		assert.NilError(t, mbox.Poll(true))
 
@@ -229,7 +229,7 @@ func Mailbox_ListMessages_Body(t *testing.T, newBack NewBackFunc, closeBack Clos
 	defer mbox.Close()
 
 	date := time.Now()
-	err := u.CreateMessage(mbox.Name(), []string{"$Test1", "$Test2"}, date, strings.NewReader(testMailString))
+	err := u.CreateMessage(mbox.Name(), []string{"$Test1", "$Test2"}, date, strings.NewReader(testMailString), mbox)
 	assert.NilError(t, err)
 	assert.NilError(t, mbox.Poll(true))
 
@@ -278,8 +278,8 @@ var testBodyStructure = &imap.BodyStructure{
 			Extended:    true,
 			Parts: []*imap.BodyStructure{
 				{
-					Size: 17,
-					Lines: 1,
+					Size:              17,
+					Lines:             1,
 					MIMEType:          "text",
 					MIMESubType:       "plain",
 					Params:            map[string]string{},
@@ -288,8 +288,8 @@ var testBodyStructure = &imap.BodyStructure{
 					DispositionParams: map[string]string{},
 				},
 				{
-					Size: 35,
-					Lines: 1,
+					Size:              35,
+					Lines:             1,
 					MIMEType:          "text",
 					MIMESubType:       "html",
 					Params:            map[string]string{},
@@ -300,8 +300,8 @@ var testBodyStructure = &imap.BodyStructure{
 			},
 		},
 		{
-			Size: 19,
-			Lines: 1,
+			Size:              19,
+			Lines:             1,
 			MIMEType:          "text",
 			MIMESubType:       "plain",
 			Params:            map[string]string{},
@@ -397,9 +397,9 @@ func Mailbox_ListMessages_Meta(t *testing.T, newBack NewBackFunc, closeBack Clos
 	defer closeBack(b)
 	u := getUser(t, b)
 	defer assert.NilError(t, u.Logout())
-	mbox := getMbox(t, u,nil)
+	mbox := getMbox(t, u, nil)
 	defer mbox.Close()
-	createMsgs(t, mbox, u,1)
+	createMsgs(t, mbox, u, 1)
 
 	t.Run("fetch bodystruct", func(t *testing.T) {
 		skipIfExcluded(t)
@@ -438,7 +438,7 @@ func Mailbox_ListMessages_Multi(t *testing.T, newBack NewBackFunc, closeBack Clo
 	defer assert.NilError(t, u.Logout())
 	mbox := getMbox(t, u, nil)
 	defer mbox.Close()
-	createMsgs(t, mbox, u,1)
+	createMsgs(t, mbox, u, 1)
 
 	t.Run("fetch uid,body[]", func(t *testing.T) {
 		skipIfExcluded(t)

--- a/mailbox_search.go
+++ b/mailbox_search.go
@@ -301,12 +301,12 @@ func Mailbox_SearchMessages(t *testing.T, newBack NewBackFunc, closeBack CloseBa
 			mbox := getMbox(t, u, nil)
 
 			// Create a message and delete it to make sure test message will have seqnum=1 and uid=2.
-			assert.NilError(t, u.CreateMessage(mbox.Name(), test.flags, test.date, strings.NewReader(testMailString)))
+			assert.NilError(t, u.CreateMessage(mbox.Name(), test.flags, test.date, strings.NewReader(testMailString), mbox))
 			assert.NilError(t, mbox.Poll(true))
 			assert.NilError(t, mbox.UpdateMessagesFlags(false, &imap.SeqSet{Set: []imap.Seq{{1, 1}}}, imap.AddFlags, true, []string{imap.DeletedFlag}))
 			assert.NilError(t, mbox.Expunge())
 
-			assert.NilError(t, u.CreateMessage(mbox.Name(), test.flags, test.date, strings.NewReader(testMailString)))
+			assert.NilError(t, u.CreateMessage(mbox.Name(), test.flags, test.date, strings.NewReader(testMailString), mbox))
 			assert.NilError(t, mbox.Poll(true))
 
 			t.Run("seq", func(t *testing.T) {

--- a/mailbox_updates.go
+++ b/mailbox_updates.go
@@ -78,10 +78,10 @@ func Mailbox_StatusUpdate(t *testing.T, newBack NewBackFunc, closeBack CloseBack
 	defer mbox.Close()
 
 	for i := uint32(1); i <= uint32(5); i++ {
-		createMsgs(t, mbox, u,1)
+		createMsgs(t, mbox, u, 1)
 		if i > uint32(len(conn.upds)) {
 			t.Fatal("Missing update #", i)
-		} 
+		}
 		switch upd := conn.upds[i-1].(type) {
 		case *backend.MailboxUpdate:
 			assert.Check(t, is.Equal(upd.Messages, i), "Wrong amount of messages in mailbox reported in update")
@@ -104,12 +104,12 @@ func Mailbox_StatusUpdate_Copy(t *testing.T, newBack NewBackFunc, closeBack Clos
 
 	srcMbox := getMbox(t, u, nil)
 	defer srcMbox.Close()
-	
+
 	conn := collectorConn{}
 	tgtMbox := getMbox(t, u, &conn)
 	defer tgtMbox.Close()
 
-	createMsgs(t, srcMbox, u,3)
+	createMsgs(t, srcMbox, u, 3)
 
 	seq, _ := imap.ParseSeqSet("2:3")
 	assert.NilError(t, srcMbox.CopyMessages(false, seq, tgtMbox.Name()))
@@ -130,7 +130,7 @@ func Mailbox_StatusUpdate_Copy(t *testing.T, newBack NewBackFunc, closeBack Clos
 func Mailbox_StatusUpdate_Move(t *testing.T, newBack NewBackFunc, closeBack CloseBackFunc) {
 	b := newBack()
 	defer closeBack(b)
-	
+
 	u := getUser(t, b)
 	defer assert.NilError(t, u.Logout())
 
@@ -157,7 +157,7 @@ func Mailbox_StatusUpdate_Move(t *testing.T, newBack NewBackFunc, closeBack Clos
 
 	// We expect 1 status update for target mailbox and two expunge updates
 	// for source mailbox.
-	
+
 	assert.Assert(t, is.Len(tgtConn.upds, 1))
 	mboxUpd, ok := tgtConn.upds[0].(*backend.MailboxUpdate)
 	if !ok {
@@ -204,10 +204,10 @@ func Mailbox_MessageUpdate(t *testing.T, newBack NewBackFunc, closeBack CloseBac
 			defer mbox.Close()
 
 			for i := 1; i <= len(initialFlags); i++ {
-				assert.NilError(t, u.CreateMessage(mbox.Name(), initialFlags[uint32(i)], time.Now(), strings.NewReader(testMsg)))
+				assert.NilError(t, u.CreateMessage(mbox.Name(), initialFlags[uint32(i)], time.Now(), strings.NewReader(testMsg), mbox))
 				assert.NilError(t, mbox.Poll(true))
 			}
-			
+
 			conn.upds = nil
 
 			seq, _ := imap.ParseSeqSet(seqset)
@@ -215,7 +215,7 @@ func Mailbox_MessageUpdate(t *testing.T, newBack NewBackFunc, closeBack CloseBac
 
 			for i := 0; i < expectedUpdates; i++ {
 				assert.Assert(t, i < len(conn.upds), "Not enough updates sent by backend")
-				
+
 				upd := conn.upds[i]
 				switch upd := upd.(type) {
 				case *backend.MessageUpdate:
@@ -314,7 +314,7 @@ func Mailbox_ExpungeUpdate(t *testing.T, newBack NewBackFunc, closeBack CloseBac
 	testSlots := func(msgsCount int, seqset string, matchedMsgs int, expectedSlots []uint32) {
 		t.Run(seqset, func(t *testing.T) {
 			skipIfExcluded(t)
-			
+
 			conn := collectorConn{}
 
 			mbox := getMbox(t, u, &conn)
@@ -359,12 +359,12 @@ func Mailbox_ExpungeUpdate(t *testing.T, newBack NewBackFunc, closeBack CloseBac
 	// Make sure backend returns seqnums, not UIDs.
 	t.Run("Not UIDs", func(t *testing.T) {
 		skipIfExcluded(t)
-		
+
 		conn := collectorConn{}
 
 		mbox := getMbox(t, u, &conn)
 		defer mbox.Close()
-		createMsgs(t, mbox, u,6)
+		createMsgs(t, mbox, u, 6)
 
 		conn.upds = nil
 
@@ -373,7 +373,7 @@ func Mailbox_ExpungeUpdate(t *testing.T, newBack NewBackFunc, closeBack CloseBac
 		assert.NilError(t, mbox.Expunge())
 
 		conn.upds = nil
-		
+
 		msgs := makeMsgSlots(5)
 		seq, _ = imap.ParseSeqSet("2,1,5")
 		assert.NilError(t, mbox.UpdateMessagesFlags(false, seq, imap.AddFlags, true, []string{imap.DeletedFlag}))

--- a/utils.go
+++ b/utils.go
@@ -65,6 +65,7 @@ func createMsgs(t *testing.T, mbox backend.Mailbox, user backend.User, count int
 			},
 			baseDate.Add(time.Duration((i+1)*24)*time.Hour),
 			strings.NewReader(testMailString),
+			mbox,
 		))
 		assert.NilError(t, mbox.Poll(true))
 	}
@@ -84,6 +85,7 @@ func createMsgsUids(t *testing.T, mbox backend.Mailbox, user backend.User, count
 			},
 			baseDate.Add(time.Duration((i+1)*24)*time.Hour),
 			strings.NewReader(testMailString),
+			mbox,
 		))
 		assert.NilError(t, mbox.Poll(true))
 	}


### PR DESCRIPTION
add mailbox parameter to backend.User.CreateMessage calls, to conform to the new signature

seems like go fmt reformatted some whitespace, I can remove those if you want